### PR TITLE
Fixed login and logout (for Satellizer 0.12.5+) bugs

### DIFF
--- a/public/scripts/authController.js
+++ b/public/scripts/authController.js
@@ -25,36 +25,33 @@
 
 				// Return an $http request for the now authenticated
 				// user so that we can flatten the promise chain
-				return $http.get('api/authenticate/user');
+				return $http.get('api/authenticate/user').then(function(response) {
+
+					// Stringify the returned data to prepare it
+					// to go into local storage
+					var user = JSON.stringify(response.data.user);
+
+					// Set the stringified user data into local storage
+					localStorage.setItem('user', user);
+
+					// The user's authenticated state gets flipped to
+					// true so we can now show parts of the UI that rely
+					// on the user being logged in
+					$rootScope.authenticated = true;
+
+					// Putting the user's data on $rootScope allows
+					// us to access it anywhere across the app
+					$rootScope.currentUser = response.data.user;
+
+					// Everything worked out so we can now redirect to
+					// the users state to view the data
+					$state.go('users');
+				});
 
 			// Handle errors
 			}, function(error) {
 				vm.loginError = true;
 				vm.loginErrorText = error.data.error;
-
-			// Because we returned the $http.get request in the $auth.login
-			// promise, we can chain the next promise to the end here
-			}).then(function(response) {
-
-				// Stringify the returned data to prepare it
-				// to go into local storage
-				var user = JSON.stringify(response.data.user);
-
-				// Set the stringified user data into local storage
-				localStorage.setItem('user', user);
-
-				// The user's authenticated state gets flipped to
-				// true so we can now show parts of the UI that rely
-				// on the user being logged in
-				$rootScope.authenticated = true;
-
-				// Putting the user's data on $rootScope allows
-				// us to access it anywhere across the app
-				$rootScope.currentUser = response.data.user;
-
-				// Everything worked out so we can now redirect to
-				// the users state to view the data
-				$state.go('users');
 			});
 		}
 	}

--- a/public/scripts/userController.js
+++ b/public/scripts/userController.js
@@ -6,7 +6,7 @@
 		.module('authApp')
 		.controller('UserController', UserController);
 
-	function UserController($http, $auth, $rootScope, $location) {
+	function UserController($http, $auth, $rootScope, $state) {
 
 		var vm = this;
 
@@ -40,8 +40,8 @@
 				// Remove the current user info from rootscope
 				$rootScope.currentUser = null;
 
-				// Redirect to root (necessary for Satellizer 0.12.5+)
-				$location.path('/');
+				// Redirect to auth (necessary for Satellizer 0.12.5+)
+				$state.go('auth');
 			});
 		}
 	}

--- a/public/scripts/userController.js
+++ b/public/scripts/userController.js
@@ -6,7 +6,7 @@
 		.module('authApp')
 		.controller('UserController', UserController);
 
-	function UserController($http, $auth, $rootScope) {
+	function UserController($http, $auth, $rootScope, $location) {
 
 		var vm = this;
 
@@ -39,6 +39,9 @@
 
 				// Remove the current user info from rootscope
 				$rootScope.currentUser = null;
+
+				// Redirect to root (necessary for Satellizer 0.12.5+)
+				$location.path('/');
 			});
 		}
 	}


### PR DESCRIPTION
Line 37 in authController.js did not chain correctly - it always executed, even if no credentials were entered. Angular would then throw TypeError: Cannot read property 'data' of undefined on line 41. This was fixed by chaining that block to $http.get('api/authenticate/user').

Next, the latest version of Satellizer (0.12.5) does not redirect on logout. Adding the following fixes the redirect: $location.path('/');
